### PR TITLE
Add chart settings

### DIFF
--- a/src/components/CdgCharts.vue
+++ b/src/components/CdgCharts.vue
@@ -1,15 +1,29 @@
 <template>
-  <div class="charts">
-    <Incidents class="chart" type="confirmed" />
-    <Incidents class="chart" type="deaths" />
-    <Incidents class="chart" type="confirmed" :logarithmic="true" />
-    <Incidents class="chart" type="deaths" :logarithmic="true" />
-    <NewIncidents class="chart" type="confirmed" />
-    <RelativeNewIncidents class="chart" type="confirmed" :averaged="true" />
-    <NewIncidents class="chart" type="deaths" />
-    <NewIncidents class="chart" type="confirmed" :averaged="true" />
-    <GrowthFactor class="chart" type="confirmed" />
-    <Mortality class="chart" />
+  <div>
+    <ChartSettings />
+    <div class="charts">
+      <Incidents class="chart" type="confirmed" :logarithmic="isLogScale" />
+      <Incidents class="chart" type="deaths" :logarithmic="isLogScale" />
+      <NewIncidents
+        class="chart"
+        type="confirmed"
+        :logarithmic="isLogScale"
+        :averaged="isAveraged"
+      />
+      <RelativeNewIncidents
+        class="chart"
+        type="confirmed"
+        :averaged="isAveraged"
+      />
+      <NewIncidents
+        class="chart"
+        type="deaths"
+        :logarithmic="isLogScale"
+        :averaged="isAveraged"
+      />
+      <GrowthFactor class="chart" type="confirmed" />
+      <Mortality class="chart" />
+    </div>
   </div>
 </template>
 
@@ -21,9 +35,11 @@ import NewIncidents from '@/components/charts/NewIncidents.vue';
 import Incidents from '@/components/charts/Incidents.vue';
 import RelativeNewIncidents from '@/components/charts/RelativeNewIncidents.vue';
 import GrowthFactor from '@/components/charts/GrowthFactor.vue';
+import ChartSettings from '@/components/misc/ChartSettings.vue';
 
 @Component({
   components: {
+    ChartSettings,
     GrowthFactor,
     RelativeNewIncidents,
     Incidents,
@@ -31,7 +47,15 @@ import GrowthFactor from '@/components/charts/GrowthFactor.vue';
     Mortality,
   },
 })
-export default class CdgCharts extends Mixins(StateMixin) {}
+export default class CdgCharts extends Mixins(StateMixin) {
+  public get isLogScale() {
+    return this.rootModule.state.selection.yAxisScaling === 'logarithmic';
+  }
+
+  public get isAveraged() {
+    return this.rootModule.state.selection.averaged;
+  }
+}
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/src/components/misc/ChartSettings.vue
+++ b/src/components/misc/ChartSettings.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="chartSettings">
+    <span>
+      <button
+        v-if="rootModule.state.selection.yAxisScaling === 'linear'"
+        @click="rootModule.actions.selectYAxisScaling('logarithmic')"
+        v-t="'buttonLabel.logarithmic'"
+      />
+      <button
+        v-else
+        @click="rootModule.actions.selectYAxisScaling('linear')"
+        v-t="'buttonLabel.linear'"
+      />
+    </span>
+    <span>
+      <button
+        v-if="rootModule.state.selection.averaged"
+        @click="rootModule.actions.setChartAveraging(false)"
+        v-t="'buttonLabel.daily'"
+      />
+      <button
+        v-else
+        @click="rootModule.actions.setChartAveraging(true)"
+        v-t="'buttonLabel.averaged'"
+      />
+    </span>
+  </div>
+</template>
+
+<script lang="ts">
+import Component from 'vue-class-component';
+import { Mixins } from 'vue-property-decorator';
+import StateMixin from '@/components/stateMixin';
+
+@Component
+export default class ChartSettings extends Mixins(StateMixin) {}
+</script>
+
+<style lang="scss" scoped>
+.chartSettings {
+  display: flex;
+
+  & span {
+    display: inline-flex;
+    justify-content: space-around;
+    width: 50%;
+  }
+}
+
+button {
+  padding: 8px;
+  border: 2px solid darken($color-input-bg, 20);
+  color: $color-input-text;
+  background-color: $color-input-bg;
+
+  &:hover,
+  &:focus {
+    background-color: darken($color-input-bg, 10);
+  }
+}
+</style>

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -30,6 +30,12 @@ export const de = {
       deaths: 'Wachstumsfaktor (Neue Todesfälle/Neue Todesfälle am Vortag)',
     },
   },
+  buttonLabel: {
+    logarithmic: 'Zeige einige Diagramme mit logarithmischer Y-Achse',
+    linear: 'Zeige alle Diagramme mit linearer Y-Achse',
+    daily: 'Zeige alle Diagramme mit täglichen Daten',
+    averaged: 'Zeige einige Diagramme mit gemittelten Daten',
+  },
   averagedOver7DaysDesc: 'Gemittelt über 7 Tage.',
   logScale: 'Mit einer logarithmischen Y-Achse dargestellt.',
 };

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -32,6 +32,12 @@ export const en: TranslationKeys = {
       deaths: 'Growth Factor (New Deaths / New Deaths the previous day)',
     },
   },
+  buttonLabel: {
+    logarithmic: 'Switch some charts to logarithmic Y-axis',
+    linear: 'Show all charts with linear Y-Axis',
+    daily: 'Show daily data in all charts',
+    averaged: 'Show some charts averaged over 7 days',
+  },
   averagedOver7DaysDesc: 'averaged over 7 days',
   logScale: 'shown with a logarithmic Y-axis',
 };

--- a/src/store/RootActions.ts
+++ b/src/store/RootActions.ts
@@ -1,7 +1,7 @@
 import { Actions } from 'vuex-smart-module';
 import RootGetters from './RootGetters';
 import RootMutations from './RootMutations';
-import { RootState, StatType, StatSubType } from '@/store/RootState';
+import { RootState, StatType, StatSubType, ScaleType } from '@/store/RootState';
 
 export default class RootActions extends Actions<
   RootState,
@@ -23,5 +23,13 @@ export default class RootActions extends Actions<
 
   public selectDate(date: string): void {
     this.commit('selectDate', date);
+  }
+
+  public selectYAxisScaling(scaling: ScaleType): void {
+    this.commit('setYAxisScaling', scaling);
+  }
+
+  public setChartAveraging(shouldChartsBeAveraged: boolean): void {
+    this.commit('setChartAveraging', shouldChartsBeAveraged);
   }
 }

--- a/src/store/RootMutations.ts
+++ b/src/store/RootMutations.ts
@@ -32,4 +32,12 @@ export default class RootMutations extends Mutations<RootState> {
   public selectDate(date: string): void {
     this.state.selection.date = date;
   }
+
+  public setYAxisScaling(scaling: 'linear' | 'logarithmic'): void {
+    this.state.selection.yAxisScaling = scaling;
+  }
+
+  public setChartAveraging(shouldChartsBeAveraged: boolean): void {
+    this.state.selection.averaged = shouldChartsBeAveraged;
+  }
 }

--- a/src/store/RootState.ts
+++ b/src/store/RootState.ts
@@ -28,6 +28,7 @@ export interface StatePopulationData {
 
 export type StatType = 'confirmed' | 'deaths';
 export type StatSubType = 'total' | 'perPop' | 'change';
+export type ScaleType = 'linear' | 'logarithmic';
 
 export interface ApplicationState {
   selection: {
@@ -35,6 +36,8 @@ export interface ApplicationState {
     type: StatType;
     subType: StatSubType;
     date: string;
+    yAxisScaling: ScaleType;
+    averaged: boolean;
   };
   statePopulation: StatePopulationData;
   confirmed: CaseRecordsByState;
@@ -52,5 +55,7 @@ export class RootState implements ApplicationState {
     type: 'confirmed',
     subType: 'total',
     date: this.availableDates[this.availableDates.length - 1],
+    yAxisScaling: 'linear',
+    averaged: false,
   };
 }

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -11,6 +11,8 @@ export const getNewRootState = (fields: Partial<RootState>): RootState => {
       type: 'confirmed',
       subType: 'total',
       date: '',
+      yAxisScaling: 'linear',
+      averaged: false,
     },
     ...fields,
   };

--- a/tests/unit/store/RootGetters.spec.ts
+++ b/tests/unit/store/RootGetters.spec.ts
@@ -37,6 +37,8 @@ describe('RootGetters', () => {
             type: 'confirmed',
             subType: 'total',
             date: '',
+            yAxisScaling: 'linear',
+            averaged: false,
           },
         }),
       });
@@ -77,6 +79,8 @@ describe('RootGetters', () => {
               type: 'confirmed',
               subType: 'total',
               date: '',
+              yAxisScaling: 'linear',
+              averaged: false,
             },
           }),
         });
@@ -111,6 +115,8 @@ describe('RootGetters', () => {
               type: 'confirmed',
               subType: 'total',
               date: '',
+              yAxisScaling: 'linear',
+              averaged: false,
             },
           }),
         });
@@ -147,6 +153,8 @@ describe('RootGetters', () => {
               type: 'confirmed',
               subType: 'total',
               date: '',
+              yAxisScaling: 'linear',
+              averaged: false,
             },
           }),
         });
@@ -171,6 +179,8 @@ describe('RootGetters', () => {
               type: 'confirmed',
               subType: 'total',
               date: '',
+              yAxisScaling: 'linear',
+              averaged: false,
             },
             deaths: {
               Sachsen: {


### PR DESCRIPTION
This reduces the total number of charts by making it possible to switch
between linear and log y-axes and daily and averaged data.